### PR TITLE
_field_email.htm is missing

### DIFF
--- a/modules/backend/widgets/form/partials/_field_email.htm
+++ b/modules/backend/widgets/form/partials/_field_email.htm
@@ -1,0 +1,16 @@
+<!-- Email -->
+<?php if ($this->previewMode): ?>
+    <span class="form-control"><?= $field->value ? e($field->value) : '&nbsp;' ?></span>
+<?php else: ?>
+    <input
+        type="email"
+        name="<?= $field->getName() ?>"
+        id="<?= $field->getId() ?>"
+        value="<?= e($field->value) ?>"
+        placeholder="<?= e(trans($field->placeholder)) ?>"
+        class="form-control"
+        autocomplete="off"
+        maxlength="254"
+        <?= $field->getAttributes() ?>
+    />
+<?php endif ?>


### PR DESCRIPTION
Following the documentation at https://octobercms.com/docs/backend/forms#field-email produces an error because there is no _field_email.htm file found in:

`modules/backend/widgets/form/partials`